### PR TITLE
Fixing the settings object

### DIFF
--- a/PythonOutputFormat.py
+++ b/PythonOutputFormat.py
@@ -17,8 +17,8 @@ class PythonOutputFormatCommand(sublime_plugin.TextCommand):
 
     def set_indentation(self):
         """Set internal variable based on the indentation settings of the document."""
-        if self.view.settings_object.get('translate_tabs_to_spaces'):
-            self.indentation = ' ' * self.view.settings_object.get('tab_size')
+        if self.view.settings().get('translate_tabs_to_spaces'):
+            self.indentation = ' ' * self.view.settings().get('tab_size')
         else:
             self.indentation = '\t'
 


### PR DESCRIPTION
What a great plugin, does exactly what I want it to do, but it wasn't quite working. "settings_object" is not an object and the error thrown in SB3 is:

```
>>> view.run_command('python_output_prettify')
Traceback (most recent call last):
  File "/Applications/Sublime Text.app/Contents/MacOS/sublime_plugin.py", line 556, in run_
    return self.run(edit)
  File "/Users/mmahoney/Library/Application Support/Sublime Text 3/Packages/Python Output Prettify/python-output-prettify.py", line 31, in run
    self.set_indentation()
  File "/Users/mmahoney/Library/Application Support/Sublime Text 3/Packages/Python Output Prettify/python-output-prettify.py", line 20, in set_indentation
    if self.view.settings_object.get('translate_tabs_to_spaces'):
AttributeError: 'NoneType' object has no attribute 'get'
```

Changing it to settings() seems to fix the issue.
